### PR TITLE
Reference Tracker from window.Package.tracker in minimongo plugin

### DIFF
--- a/src/plugins/minimongo/inject.js
+++ b/src/plugins/minimongo/inject.js
@@ -23,7 +23,7 @@ let __talkToExtension = null;
 module.exports = {
   setup : (talkToExtension) => {
     __talkToExtension = talkToExtension;
-    Tracker.autorun(function(){
+    Package.tracker.Tracker.autorun(function(){
       const collections = Meteor.connection._mongo_livedata_collections;
       for(let i in collections) {
         collections[i].find();


### PR DESCRIPTION
In newer versions of Meteor, `Tracker` is not always a global variable, however `Package` is. This PR looks for Tracker in `Package.tracker` instead of in the global scope.

Fixes #61 